### PR TITLE
Gridotto ui kodlarını incele

### DIFF
--- a/src/app/create-draw/page.tsx
+++ b/src/app/create-draw/page.tsx
@@ -32,7 +32,6 @@ export default function CreateDrawPage() {
     maxTickets: 100,
     requirementType: 0,
     tokenIds: [],
-    winnerCount: 1,
     prizeAsset: '', // For token/NFT draws
     selectedAsset: null // Store selected asset metadata
   });

--- a/src/components/create-draw/DrawSettings.tsx
+++ b/src/components/create-draw/DrawSettings.tsx
@@ -23,15 +23,32 @@ export function DrawSettings({ drawData, updateDrawData }: DrawSettingsProps) {
           </label>
           <input
             type="number"
-            step="0.01"
-            min="0.01"
-            value={drawData.ticketPrice || ''}
-            onChange={(e) => updateDrawData({ ticketPrice: parseFloat(e.target.value) || 0.01 })}
+            step="0.001"
+            min="0"
+            value={drawData.ticketPrice === 0 ? '' : drawData.ticketPrice || ''}
+            onChange={(e) => {
+              const value = e.target.value;
+              if (value === '') {
+                updateDrawData({ ticketPrice: 0 });
+              } else {
+                const numValue = parseFloat(value);
+                if (!isNaN(numValue) && numValue >= 0) {
+                  updateDrawData({ ticketPrice: numValue });
+                }
+              }
+            }}
+            onBlur={(e) => {
+              // On blur, if value is empty or 0, keep it as 0
+              const value = e.target.value;
+              if (value === '' || parseFloat(value) === 0) {
+                updateDrawData({ ticketPrice: 0 });
+              }
+            }}
             className="input-glass w-full"
-            placeholder="0.01"
+            placeholder="0"
           />
           <p className="text-xs text-gray-400 mt-1">
-            Minimum 0.01 LYX per ticket
+            Enter 0 for free tickets, or any amount in LYX
           </p>
         </div>
 
@@ -73,49 +90,6 @@ export function DrawSettings({ drawData, updateDrawData }: DrawSettingsProps) {
             Leave as 0 for unlimited tickets
           </p>
         </div>
-
-        {/* Winner Count - Only for NFT draws with multiple tokens */}
-        {drawData.drawType === 'NFT' && (
-          <div>
-            <label className="block text-sm font-medium text-gray-300 mb-2">
-              Number of Winners
-            </label>
-            <input
-              type="number"
-              min="1"
-              max={drawData.tokenIds?.length || 1}
-              value={drawData.winnerCount || 1}
-              onChange={(e) => updateDrawData({ winnerCount: parseInt(e.target.value) || 1 })}
-              className="input-glass w-full"
-              disabled={!drawData.tokenIds || drawData.tokenIds.length <= 1}
-            />
-            <p className="text-xs text-gray-400 mt-1">
-              {drawData.tokenIds && drawData.tokenIds.length > 1 
-                ? `You have ${drawData.tokenIds.length} NFTs. Each winner gets one NFT.`
-                : 'Add multiple NFTs to have multiple winners'}
-            </p>
-          </div>
-        )}
-
-        {/* Winner Count - For other draw types */}
-        {drawData.drawType !== 'NFT' && (
-          <div>
-            <label className="block text-sm font-medium text-gray-300 mb-2">
-              Number of Winners
-            </label>
-            <input
-              type="number"
-              min="1"
-              max="100"
-              value={drawData.winnerCount || 1}
-              onChange={(e) => updateDrawData({ winnerCount: parseInt(e.target.value) || 1 })}
-              className="input-glass w-full"
-            />
-            <p className="text-xs text-gray-400 mt-1">
-              Prize will be split equally among winners
-            </p>
-          </div>
-        )}
       </div>
 
       {/* Advanced Settings */}

--- a/src/components/create-draw/ReviewAndCreate.tsx
+++ b/src/components/create-draw/ReviewAndCreate.tsx
@@ -170,7 +170,9 @@ export const ReviewAndCreate = ({ drawData, onCreate }: ReviewAndCreateProps) =>
           
           <div>
             <p className="text-sm text-gray-400">Ticket Price</p>
-            <p className="text-white font-medium">{drawData.ticketPrice} LYX</p>
+            <p className="text-white font-medium">
+              {drawData.ticketPrice === 0 ? 'Free' : `${drawData.ticketPrice} LYX`}
+            </p>
           </div>
           
           <div>

--- a/src/types/create-draw.ts
+++ b/src/types/create-draw.ts
@@ -15,12 +15,4 @@ export interface DrawData {
   // NFT specific
   nftContract?: string;
   tokenIds: string[];
-  
-  // Multi-winner
-  isMultiWinner?: boolean;
-  winnerCount?: number;
-  tiers?: Array<{
-    position: number;
-    percentage: number;
-  }>;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,7 +20,6 @@ export interface DrawData {
   minFollowers?: number;
   
   // Advanced settings (all optional)
-  winnerCount?: number;
   platformFeePercent?: number; // Platform fee is 5% by default
   minParticipants?: number;
   maxParticipants?: number;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Refactor Gridotto UI to fix active draws display, monthly participant count, enable 0 ticket price, and remove multi-winner options.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses several reported UI issues:
- **Active Draws:** Removed the 10-draw limit and added special badging and sorting for platform draws.
- **Monthly Draw:** Implemented a fallback to estimate monthly draw participants when the direct count is zero.
- **Ticket Price:** Updated the ticket price input to correctly handle and display '0' as "Free".
- **Multi-Winner:** Removed all UI elements and type definitions related to the multi-winner feature, as it is currently unsupported.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4834866-0f32-44e3-a6ab-e3768fa3afe5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e4834866-0f32-44e3-a6ab-e3768fa3afe5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>